### PR TITLE
fix instant win bug

### DIFF
--- a/app/src/main/java/com/example/lazar_android_app/GameActivity.java
+++ b/app/src/main/java/com/example/lazar_android_app/GameActivity.java
@@ -94,7 +94,7 @@ public class GameActivity extends AppCompatActivity implements SensorEventListen
     private FusedLocationProviderClient fusedLocationProviderClient;
     private boolean stopHumanDetection = false;
 
-    private static int readyToFire = 2;
+    private int readyToFire = 2;
 
     Camera camera;
     CameraControl cameraControl;
@@ -618,7 +618,6 @@ public class GameActivity extends AppCompatActivity implements SensorEventListen
                 try {
                     if(readyToFire != 0) {
                         readyToFire--;
-                        return;
                     }
                     _gameStatus = response.getString("gameStatus");
                     _health = response.getInt("health");


### PR DESCRIPTION
readyToFire should be an object variable and not a class variable. Prevents a second game from ending prematurely